### PR TITLE
Configured database for role-based authentication using Spring Security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,27 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/springsecuritydemo/securityconfig/SecurityConfig.java
+++ b/src/main/java/com/example/springsecuritydemo/securityconfig/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -20,14 +21,18 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class SecurityConfig {
 
     @Bean
-    SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception{
-        http.authorizeHttpRequests((request) -> request.anyRequest().authenticated());
+    SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests((request) ->
+               request.requestMatchers("/h2-console/**").permitAll().anyRequest().authenticated());
         http.sessionManagement((session
                 -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)));
         //http.formLogin(withDefaults());
         http.httpBasic(withDefaults());
+        http.headers(headers-> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
+        http.csrf(csrf -> csrf.disable());
         return http.build();
     }
+
     @Bean
     public UserDetailsService userDetailsService() {
         UserDetails user1 = User.withUsername("user1")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,10 +3,13 @@ spring.application.name=springsecuritydemo
 server.port=8084
 server.servlet.context-path=/springsecuritydemo
 
-
-#spring security properties
-spring.applicaion.name=springsecuritydemo
+# Spring Security properties
 spring.security.user.name=admin
 spring.security.user.password=admin
 
-
+# database configuration
+spring.datasource.url=jdbc:mysql://localhost:3300/springsecuritydemo
+spring.datasource.username=root
+spring.datasource.password=root
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
Database Configuration:

#Added database properties in application.properties for MySQL configuration.
- Configured Hibernate to use MySQL 8 dialect.
- Enabled automatic schema updates (spring.jpa.hibernate.ddl-auto=update).

#Spring Security Setup:
- Implemented a security configuration class (SecurityConfig) to handle HTTP security and user authentication.
- Enabled method security to restrict access to specific endpoints based on user roles.
- Configured in-memory user details service for initial testing with predefined users and roles (USER and ADMIN).
- Disabled CSRF protection and configured headers for H2 console access.

#Controller:
- Created a GreetingsController with endpoints /greet, /user, and /admin.
- Applied role-based access control using the @PreAuthorize annotation.