### PR TITLE
Add security roles to GreetingsController endpoints

### DIFF
--- a/src/main/java/com/example/springsecuritydemo/GreetingsController.java
+++ b/src/main/java/com/example/springsecuritydemo/GreetingsController.java
@@ -17,6 +17,7 @@ public class GreetingsController {
         return "hello user";
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/admin")
     public String adminEndPoint() {
         return "hello admin";

--- a/src/main/java/com/example/springsecuritydemo/securityconfig/SecurityConfig.java
+++ b/src/main/java/com/example/springsecuritydemo/securityconfig/SecurityConfig.java
@@ -1,17 +1,22 @@
 package com.example.springsecuritydemo.securityconfig;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+
+import javax.sql.DataSource;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -19,6 +24,9 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
+
+    @Autowired
+    DataSource dataSource;
 
     @Bean
     SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -29,7 +37,7 @@ public class SecurityConfig {
         //http.formLogin(withDefaults());
         http.httpBasic(withDefaults());
         http.headers(headers-> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
-        http.csrf(csrf -> csrf.disable());
+        http.csrf(AbstractHttpConfigurer::disable);
         return http.build();
     }
 
@@ -44,6 +52,10 @@ public class SecurityConfig {
                 .roles("ADMIN")
                 .build();
 
-        return new InMemoryUserDetailsManager(user1, admin);
+        JdbcUserDetailsManager userDetailsManager = new JdbcUserDetailsManager(dataSource);
+        userDetailsManager.createUser(user1);
+        userDetailsManager.createUser(admin);
+        return userDetailsManager;
+       // return new InMemoryUserDetailsManager(user1, admin);
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE springsecuritydemo.users (
+                                          username VARCHAR(50) NOT NULL PRIMARY KEY,
+                                          password VARCHAR(500) NOT NULL,
+                                          enabled BOOLEAN NOT NULL
+);
+
+CREATE TABLE springsecuritydemo.authorities (
+                                                username VARCHAR(50) NOT NULL,
+                                                authority VARCHAR(50) NOT NULL,
+                                                CONSTRAINT fk_authorities_users FOREIGN KEY (username) REFERENCES springsecuritydemo.users(username)
+);
+
+
+CREATE UNIQUE INDEX ix_auth_username ON springsecuritydemo.authorities (username, authority);
+
+
+


### PR DESCRIPTION
This pull request introduces significant enhancements to the security configuration and endpoint access control within the springsecuritydemo application. Key changes include:  
Implementation of role-based access control on GreetingsController endpoints, ensuring that only authenticated users with appropriate roles can access specific resources. The /user endpoint is now accessible to users with the 'USER' role, and the /admin endpoint is accessible to users with the 'ADMIN' role.
Transition from in-memory user details to JDBC-based user management, leveraging the application's database for storing user credentials and authorities. This shift enhances the application's scalability and ease of user management.
Configuration adjustments to the SecurityConfig class to support JDBC user details and disable CSRF for API compatibility, while also ensuring the application's security headers are appropriately configured.
Inclusion of SQL schema for user and authority tables, facilitating the persistence of user details and their roles in the database.
These changes collectively bolster the application's security posture, streamline user management, and ensure that access to sensitive endpoints is meticulously controlled based on the authenticated user's role.